### PR TITLE
[FIX] Broken link in README, wrong file suffix on Markdown file

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The gem's test suite should also serve as detailed documentation for each matche
 
 ## Development
 
-See [devlopment.txt](https://github.com/elabs/elabs_matchers/blob/master/development.rb)
+See [development.md](https://github.com/elabs/elabs_matchers/blob/master/development.md)
 
 ## Contributors
 

--- a/development.md
+++ b/development.md
@@ -1,5 +1,5 @@
 ## Setting up:
-#
+
 1. Fork the gem
 2. Clone you fork to your local machine
 3. Run:
@@ -8,7 +8,7 @@
    rspec
 
 ## Pull requests:
-#
+
 Pull requests are appreciated. Before submitting please consider the following:
 
 * Public methods are documented.


### PR DESCRIPTION
The link to the "development" file was broken.  It will look broken until this PR is merged since it points to master.

No need to release a gem, and please don't add me to "Contributors" :)